### PR TITLE
fix: ghalint の検証を gh attestation verify に切り替え

### DIFF
--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -48,10 +48,14 @@ jobs:
       - name: Install ghalint
         env:
           GHALINT_VERSION: "1.5.5"
+          GH_TOKEN: ${{ github.token }}
         run: |
-          curl -sLO "https://github.com/suzuki-shunsuke/ghalint/releases/download/v${GHALINT_VERSION}/ghalint_${GHALINT_VERSION}_linux_amd64.tar.gz"
-          curl -sLO "https://github.com/suzuki-shunsuke/ghalint/releases/download/v${GHALINT_VERSION}/ghalint_${GHALINT_VERSION}_checksums.txt"
-          sha256sum --check --ignore-missing "ghalint_${GHALINT_VERSION}_checksums.txt"
+          gh release download "v${GHALINT_VERSION}" \
+            -R suzuki-shunsuke/ghalint \
+            -p "ghalint_${GHALINT_VERSION}_linux_amd64.tar.gz"
+          gh attestation verify "ghalint_${GHALINT_VERSION}_linux_amd64.tar.gz" \
+            -R suzuki-shunsuke/ghalint \
+            --signer-workflow suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
           tar xzf "ghalint_${GHALINT_VERSION}_linux_amd64.tar.gz" -C /usr/local/bin ghalint
 
       - name: Run ghalint


### PR DESCRIPTION
## Summary
- ghalint バイナリの検証方式を `sha256sum` checksums から `gh attestation verify` (SLSA provenance) に切り替え
- ハッシュ一致だけでなく、ビルド出自（リポジトリ・ワークフロー）まで暗号的に検証

## Before / After

**Before (checksums)**:
```yaml
curl -sLO ".../ghalint_1.5.5_linux_amd64.tar.gz"
curl -sLO ".../ghalint_1.5.5_checksums.txt"
sha256sum --check --ignore-missing "ghalint_1.5.5_checksums.txt"
tar xzf ...
```

**After (attestation)**:
```yaml
gh release download "v1.5.5" -R suzuki-shunsuke/ghalint -p "*.tar.gz"
gh attestation verify "*.tar.gz" -R suzuki-shunsuke/ghalint \
  --signer-workflow suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
tar xzf ...
```

## Test plan
- [ ] CI で `gh attestation verify` が正常動作することを確認
- [ ] `permissions: {}` のままで GitHub Attestation API にアクセスできることを確認