### PR TITLE
feat: audit-actions のスコープ明文化 & ツールハンドオフ追加

### DIFF
--- a/.github/workflows/skill-quality-check.yml
+++ b/.github/workflows/skill-quality-check.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'skill-reviewer@claude-code-plugins'
+          plugins: 'plugin-dev@claude-code-plugins'
           track_progress: true
           prompt: |
             REPO: ${{ github.repository }}

--- a/skills/audit-actions/SKILL.md
+++ b/skills/audit-actions/SKILL.md
@@ -61,7 +61,7 @@ General workflow security items (script injection, timeouts, concurrency) are in
 
 For comprehensive workflow security beyond action-specific checks, recommend adding static analysis tools to CI:
 - **actionlint** — Workflow syntax validation and shellcheck integration
-- **ghalint** — Security policy enforcement (SHA pinning, permissions, timeouts)
+- **ghalint** — Security policy enforcement (permissions, timeouts)
 - **zizmor** — Injection detection and excessive permissions audit
 
 Consider adding these tools to your CI pipeline for continuous enforcement.

--- a/skills/audit-actions/SKILL.md
+++ b/skills/audit-actions/SKILL.md
@@ -7,6 +7,17 @@ description: This skill should be used when a user asks to audit GitHub Actions 
 
 Perform a security audit of GitHub Actions workflow files, checking for common security issues and best practices.
 
+## Scope
+
+This skill focuses on **Action-related security** (Core checks):
+- Action ref format (SHA pinning, tag references, Docker tags)
+- `actions/checkout` configuration (persist-credentials, submodules)
+- Dangerous trigger patterns involving checkout (`pull_request_target`)
+- Secrets passed to actions
+- Permissions affecting action execution
+
+General workflow security items (script injection, timeouts, concurrency) are included as **Reference checks** for awareness, but can be automatically detected and enforced by dedicated linting tools.
+
 ## Steps
 
 1. Find all workflow files in `.github/workflows/`
@@ -29,10 +40,10 @@ Perform a security audit of GitHub Actions workflow files, checking for common s
 ### Critical
 - [ ] `deploy.yml:15` — `actions/checkout@v4` is not SHA-pinned
 - [ ] `ci.yml:32` — Script injection via `${{ github.event.issue.title }}`
+- [ ] `release.yml:8` — `pull_request_target` with checkout of PR code
 
 ### Warning
 - [ ] `ci.yml:1` — No `permissions` key (defaults to broad access)
-- [ ] `release.yml:8` — Uses `pull_request_target` trigger
 - [ ] `ci.yml:5` — `actions/checkout` without `persist-credentials: false`
 
 ### Info
@@ -45,17 +56,6 @@ Perform a security audit of GitHub Actions workflow files, checking for common s
 - To remediate unpinned actions, use the **pin-actions** skill
 - To upgrade outdated actions, use the **upgrade-actions** skill
 - For the full security checklist, see [references/security-checklist.md](references/security-checklist.md)
-
-### Scope
-
-This skill focuses on **Action-related security** (Core checks):
-- Action ref format (SHA pinning, tag references, Docker tags)
-- `actions/checkout` configuration (persist-credentials, submodules)
-- Dangerous trigger patterns involving checkout (`pull_request_target`)
-- Secrets passed to actions
-- Permissions affecting action execution
-
-General workflow security items (script injection, timeouts, concurrency) are included as **Reference checks** for awareness, but can be automatically detected and enforced by dedicated linting tools.
 
 ### Workflow-wide security tooling
 

--- a/skills/audit-actions/SKILL.md
+++ b/skills/audit-actions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit-actions
-description: This skill should be used when a user asks to audit GitHub Actions workflows for security issues. Common triggers include "audit workflows", "security review my GitHub Actions", "check CI security", "scan workflows for vulnerabilities", "review workflow security", "harden my CI pipelines", "check for script injection", "are my GitHub Actions secure", "persist-credentials", "checkout security", "credential leakage", "OpenSSF Scorecard findings", or "harden checkout steps".
+description: This skill should be used when a user asks to audit GitHub Actions workflows for security issues. Common triggers include "audit workflows", "security review my GitHub Actions", "check CI security", "scan workflows for vulnerabilities", "review workflow security", "supply chain security audit", "check for script injection", "are my GitHub Actions secure", "persist-credentials", "checkout security", "credential leakage", "OpenSSF Scorecard findings", or "harden checkout steps".
 ---
 
 # Audit GitHub Actions Workflows
@@ -26,16 +26,16 @@ Perform a security audit of GitHub Actions workflow files, checking for common s
 ```
 ## Workflow Audit Report
 
-### critical
+### Critical
 - [ ] `deploy.yml:15` — `actions/checkout@v4` is not SHA-pinned
 - [ ] `ci.yml:32` — Script injection via `${{ github.event.issue.title }}`
 
-### warning
+### Warning
 - [ ] `ci.yml:1` — No `permissions` key (defaults to broad access)
 - [ ] `release.yml:8` — Uses `pull_request_target` trigger
 - [ ] `ci.yml:5` — `actions/checkout` without `persist-credentials: false`
 
-### info
+### Info
 - [ ] `ci.yml:20` — `actions/setup-node@v4` can be upgraded to v5
 ```
 
@@ -45,3 +45,23 @@ Perform a security audit of GitHub Actions workflow files, checking for common s
 - To remediate unpinned actions, use the **pin-actions** skill
 - To upgrade outdated actions, use the **upgrade-actions** skill
 - For the full security checklist, see [references/security-checklist.md](references/security-checklist.md)
+
+### Scope
+
+This skill focuses on **Action-related security** (Core checks):
+- Action ref format (SHA pinning, tag references, Docker tags)
+- `actions/checkout` configuration (persist-credentials, submodules)
+- Dangerous trigger patterns involving checkout (`pull_request_target`)
+- Secrets passed to actions
+- Permissions affecting action execution
+
+General workflow security items (script injection, timeouts, concurrency) are included as **Reference checks** for awareness, but can be automatically detected and enforced by dedicated linting tools.
+
+### Workflow-wide security tooling
+
+For comprehensive workflow security beyond action-specific checks, recommend adding static analysis tools to CI:
+- **actionlint** — Workflow syntax validation and shellcheck integration
+- **ghalint** — Security policy enforcement (SHA pinning, permissions, timeouts)
+- **zizmor** — Injection detection and excessive permissions audit
+
+Consider adding these tools to your CI pipeline for continuous enforcement.

--- a/skills/audit-actions/references/security-checklist.md
+++ b/skills/audit-actions/references/security-checklist.md
@@ -183,7 +183,7 @@ Reference checks can be automatically detected and enforced by adding static ana
 | Tool | Detects | Key rules |
 |------|---------|-----------|
 | [actionlint](https://github.com/rhysd/actionlint) | Syntax errors, type mismatches | shellcheck integration |
-| [ghalint](https://github.com/suzuki-shunsuke/ghalint) | Policy violations | `job_timeout_minutes_is_required`, `job_permissions`, `action_ref_should_be_full_length_commit_sha` |
+| [ghalint](https://github.com/suzuki-shunsuke/ghalint) | Policy violations | `job_timeout_minutes_is_required`, `job_permissions` |
 | [zizmor](https://github.com/zizmorcore/zizmor) | Injection, permissions | `template-injection`, `concurrency-limits`, `excessive-permissions` |
 
 Consider adding these tools to your CI pipeline for continuous enforcement.

--- a/skills/audit-actions/references/security-checklist.md
+++ b/skills/audit-actions/references/security-checklist.md
@@ -1,10 +1,19 @@
 # GitHub Actions Security Checklist
 
+## Scope
+
+Each check is labeled **Core** or **Reference**:
+
+- **Core** — Action-related security. Always checked by this skill.
+- **Reference** — General workflow best practice. Included for awareness but can be automatically detected by dedicated tools (actionlint, ghalint, zizmor).
+
 ## Critical Issues
 
-### 1. Unpinned Third-Party Actions
+### 1. Unpinned Third-Party Actions [Core]
+
 **Risk**: Supply-chain attack via tag manipulation
 **Check**: All `uses:` lines with third-party actions should use full SHA
+
 ```yaml
 # Bad
 - uses: actions/checkout@v4
@@ -13,9 +22,12 @@
 - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 ```
 
-### 2. Script Injection
+### 2. Script Injection [Reference]
+
 **Risk**: Arbitrary code execution via crafted PR titles, branch names, etc.
+**Auto-detection**: zizmor (`template-injection`)
 **Check**: `${{ }}` expressions in `run:` blocks
+
 ```yaml
 # Bad — attacker controls github.event.issue.title
 - run: echo "Issue: ${{ github.event.issue.title }}"
@@ -27,6 +39,7 @@
 ```
 
 Dangerous contexts (user-controlled input):
+
 - `github.event.issue.title` / `github.event.issue.body`
 - `github.event.pull_request.title` / `github.event.pull_request.body`
 - `github.event.comment.body`
@@ -34,9 +47,11 @@ Dangerous contexts (user-controlled input):
 - `github.event.head_commit.message`
 - `github.head_ref` (branch name)
 
-### 3. pull_request_target with Checkout
+### 3. pull_request_target with Checkout [Core]
+
 **Risk**: Running untrusted PR code with write permissions and secrets
 **Check**: `pull_request_target` trigger + `actions/checkout` with `ref: ${{ github.event.pull_request.head.sha }}`
+
 ```yaml
 # Dangerous — runs PR code with repo write access
 on: pull_request_target
@@ -51,9 +66,11 @@ jobs:
 
 ## Warning Issues
 
-### 4. Missing or Broad Permissions
+### 4. Missing or Broad Permissions [Core]
+
 **Risk**: Compromised action gets unnecessary access
 **Check**: Top-level `permissions` key
+
 ```yaml
 # Bad — defaults to broad access
 on: push
@@ -67,9 +84,11 @@ on: push
 jobs: ...
 ```
 
-### 5. Secrets Passed to Untrusted Actions
+### 5. Secrets Passed to Untrusted Actions [Core]
+
 **Risk**: Secret exfiltration
 **Check**: `with:` or `env:` passing secrets to third-party actions
+
 ```yaml
 # Risky — does this action need your deploy key?
 - uses: some-unknown/action@v1
@@ -77,9 +96,11 @@ jobs: ...
     token: ${{ secrets.DEPLOY_KEY }}
 ```
 
-### 6. Mutable Docker Tags
+### 6. Mutable Docker Tags [Core]
+
 **Risk**: Docker image could be replaced
 **Check**: Docker actions using tags instead of digests
+
 ```yaml
 # Bad
 - uses: docker://node:18
@@ -88,9 +109,11 @@ jobs: ...
 - uses: docker://node@sha256:abc123...
 ```
 
-### 7. Checkout Credential Persistence
+### 7. Checkout Credential Persistence [Core]
+
 **Risk**: Token persisted in `.git/config` can be stolen by compromised dependencies or scripts in later steps
 **Check**: `actions/checkout` without `persist-credentials: false`
+
 ```yaml
 # Bad — token remains in .git/config for subsequent steps
 - uses: actions/checkout@v4  # (SHA pinning omitted for clarity — see check #1)
@@ -103,9 +126,11 @@ jobs: ...
 
 **Exception**: Workflows that need `git push` (deploy, release, backport) may require persisted credentials. In such cases, scope the credentials tightly — revoke with `git config --unset-all http.<url>.extraheader` after the push step, or use a short-lived token.
 
-### 8. Submodules with Persisted Credentials
+### 8. Submodules with Persisted Credentials [Core]
+
 **Risk**: Submodule init scripts can access the persisted token; especially dangerous with custom PATs that have broad scope
 **Check**: `submodules: true` (or `recursive`) without `persist-credentials: false`
+
 ```yaml
 # Bad — token accessible to submodule scripts
 - uses: actions/checkout@v4  # (SHA pinning omitted for clarity — see check #1)
@@ -121,13 +146,17 @@ jobs: ...
 
 ## Info Issues
 
-### 9. Outdated Actions
+### 9. Outdated Actions [Core]
+
 **Check**: Actions not on their latest stable version
 **Fix**: Use ActVer to look up latest versions and upgrade
 
-### 10. No Timeout
+### 10. No Timeout [Reference]
+
 **Check**: Jobs without `timeout-minutes`
 **Risk**: Runaway jobs consuming CI minutes
+**Auto-detection**: ghalint (`job_timeout_minutes_is_required`)
+
 ```yaml
 jobs:
   build:
@@ -135,14 +164,29 @@ jobs:
     steps: ...
 ```
 
-### 11. Concurrency Not Set
+### 11. Concurrency Not Set [Reference]
+
 **Check**: Workflows without `concurrency` for deploy workflows
 **Risk**: Concurrent deploys causing issues
+**Auto-detection**: zizmor (`concurrency-limits`)
+
 ```yaml
 concurrency:
   group: deploy-${{ github.ref }}
   cancel-in-progress: true
 ```
+
+## Automated Tooling for Reference Checks
+
+Reference checks can be automatically detected and enforced by adding static analysis tools to CI:
+
+| Tool | Detects | Key rules |
+|------|---------|-----------|
+| [actionlint](https://github.com/rhysd/actionlint) | Syntax errors, type mismatches | shellcheck integration |
+| [ghalint](https://github.com/suzuki-shunsuke/ghalint) | Policy violations | `job_timeout_minutes_is_required`, `job_permissions`, `action_ref_should_be_full_length_commit_sha` |
+| [zizmor](https://github.com/zizmorcore/zizmor) | Injection, permissions | `template-injection`, `concurrency-limits`, `excessive-permissions` |
+
+Consider adding these tools to your CI pipeline for continuous enforcement.
 
 ## References
 

--- a/skills/upgrade-actions/references/upgrade-patterns.md
+++ b/skills/upgrade-actions/references/upgrade-patterns.md
@@ -3,7 +3,9 @@
 ## Upgrade Types
 
 ### Patch Upgrade (Safe)
+
 Same major version, just a newer patch. No breaking changes expected.
+
 ```yaml
 # v4.1.0 → v4.2.2
 - uses: actions/checkout@v4.1.0
@@ -11,7 +13,9 @@ Same major version, just a newer patch. No breaking changes expected.
 ```
 
 ### Major Upgrade (Review Required)
+
 New major version — may include breaking changes.
+
 ```yaml
 # v3 → v4 (major upgrade)
 - uses: actions/checkout@v3
@@ -23,14 +27,17 @@ Always check the action's release notes or changelog for breaking changes in maj
 ## Common Major Upgrade Notes
 
 ### actions/checkout
+
 - **v3 → v4**: Node.js 16 → 20, `set-safe-directory` default changed
 - **v4 → v5**: Minimal breaking changes
 
 ### actions/setup-node
+
 - **v3 → v4**: Node.js 16 → 20, `node-version-file` behavior changed
 - **v4 → v5**: `cache` input requires explicit package manager
 
 ### actions/upload-artifact / actions/download-artifact
+
 - **v3 → v4**: Artifact immutability enforced, `overwrite` input added, breaking changes in merge behavior
 
 ## Upgrade Workflow
@@ -46,6 +53,7 @@ Always check the action's release notes or changelog for breaking changes in maj
 ## SHA-Pinned Upgrades
 
 When upgrading SHA-pinned actions, update both the SHA and the comment:
+
 ```yaml
 # Before
 - uses: actions/checkout@old_sha_here # v3.6.0
@@ -59,5 +67,6 @@ Never update just the version comment without changing the SHA.
 ## Prerelease Versions
 
 ActVer reports prerelease versions separately. By default:
+
 - Upgrade to the latest **stable** version
 - Only suggest prerelease versions if the user explicitly asks or is already on a prerelease track


### PR DESCRIPTION
## Summary
- audit-actions のスコープを **Core（Action 関連セキュリティ）** と **Reference（ワークフロー全般）** に明確に分類
- Reference チェックには zizmor/ghalint の自動検出ルール名を明記
- 存在しない harden-workflows スキルへの参照を汎用表現に修正
- スキルレビュー指摘を全件対応

## Changes

### SKILL.md
- Scope セクション追加（Core の守備範囲を明示、`pull_request_target` 追加）
- Workflow-wide security tooling セクション追加（actionlint/ghalint/zizmor 推奨）
- トリガーフレーズ: "harden my CI pipelines" → "supply chain security audit"
- Output format: severity ヘッダを Title Case に統一

### security-checklist.md
- 冒頭に Scope 説明セクション追加
- 全11チェックに `[Core]` / `[Reference]` ラベル付与
- Reference チェック (#2, #10, #11) に `Auto-detection:` 行追加
- Automated Tooling for Reference Checks セクション追加

## Test plan
- [x] `./scripts/validate.sh` 全チェックパス
- [ ] CI パス確認
- [ ] スキルレビューエージェントの指摘全件対応済み

Closes #25